### PR TITLE
refactored BT reset and selection keys

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -106,10 +106,10 @@
 
         adjust {
             bindings = <
-&none  &kp LS(LG(NUMBER_4))  &kp C_MUTE  &kp C_VOL_DN  &kp C_VOL_UP      &none         &bt BT_CLR  &none    &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &none    &tog 5
-&none  &kp LS(LG(N5))        &none       &kp C_PREV    &kp C_PLAY_PAUSE  &kp C_NEXT    &bt BT0     &bt BT1  &bt BT2               &bt BT3               &bt BT4  &tog 4
-&none  &kp LS(LG(NUMBER_3))  &none       &none         &none             &none         &none       &none    &none                 &none                 &none    &none
-                                         &none         &trans            &none         &none       &trans   &none
+&none  &kp LS(LG(NUMBER_4))  &kp C_MUTE  &kp C_VOL_DN  &kp C_VOL_UP      &none         &none  &none       &kp C_BRIGHTNESS_DEC  &kp C_BRIGHTNESS_INC  &none  &tog 5
+&none  &kp LS(LG(N5))        &none       &kp C_PREV    &kp C_PLAY_PAUSE  &kp C_NEXT    &none  &bt BT_NXT  &bt BT_PRV            &none                 &none  &tog 4
+&none  &kp LS(LG(NUMBER_3))  &none       &none         &none             &none         &none  &none       &none                 &none                 &none  &none
+                                         &none         &trans            &none         &none  &trans      &none
             >;
 
             label = "misc";
@@ -117,10 +117,10 @@
 
         system {
             bindings = <
-&bootloader  &none  &none  &none  &none  &tog 4    &tog 4  &none  &none  &none  &none  &bootloader
-&none        &none  &none  &none  &none  &none     &none   &none  &none  &none  &none  &none
-&none        &none  &none  &none  &none  &none     &none   &none  &none  &none  &none  &none
-                           &none  &none  &none     &none   &none  &none
+&bootloader  &none  &none  &none  &none  &tog 4    &tog 4  &bt BT_CLR  &none  &none  &none  &bootloader
+&none        &none  &none  &none  &none  &none     &none   &none       &none  &none  &none  &none
+&none        &none  &none  &none  &none  &none     &none   &none       &none  &none  &none  &none
+                           &none  &none  &none     &none   &none       &none
             >;
 
             label = "system";


### PR DESCRIPTION
1. moved BT-clear / BT-reset key to `system` layer (from `adjust` layer) to make it harder to hit it accidentally
2. replaced BT-N profile keys with Next/Prev profile keys